### PR TITLE
Change python2 to python

### DIFF
--- a/docs_docs_common.mk
+++ b/docs_docs_common.mk
@@ -17,7 +17,7 @@
 SPHINXOPTS    =
 # note: this is changed from sphinx-build so it depends on default python interpreter, not on /bin/sphinx-build
 # (which will be the most recently installed version of sphinx and may not match)
-SPHINXBUILD   = python2 -m sphinx
+SPHINXBUILD   = python -m sphinx
 PAPER         =
 BUILDDIR      = _build
 


### PR DESCRIPTION
For some Mac users, if there is only one python version (2.7) installed on their PC and the PATH of python2 is not added in ~/.profile, they will get the error `make: python2: No such file or directory` .